### PR TITLE
Hide wait for available step in instructions when already available

### DIFF
--- a/app/pages/index.html
+++ b/app/pages/index.html
@@ -69,7 +69,7 @@
             <div class="card How">
                 <h3>Hoe werkt het?</h3>
                 <ol>
-                    <li id="waitAvailable">Wacht tot er een dictee beschikbaar is.</li>
+                    <li id="wait-available">Wacht tot er een dictee beschikbaar is.</li>
                     <li>Klik hier links op "Deelnemen!".</li>
                     <li>Lees het reglement zorgvuldig door en klik onderaan op "Ik ga akkoord".</li>
                     <li>Vul je voor- en achternaam in.</li>

--- a/app/pages/index.html
+++ b/app/pages/index.html
@@ -69,7 +69,7 @@
             <div class="card How">
                 <h3>Hoe werkt het?</h3>
                 <ol>
-                    <li>Wacht tot er een dictee beschikbaar is.</li>
+                    <li id="waitAvailable">Wacht tot er een dictee beschikbaar is.</li>
                     <li>Klik hier links op "Deelnemen!".</li>
                     <li>Lees het reglement zorgvuldig door en klik onderaan op "Ik ga akkoord".</li>
                     <li>Vul je voor- en achternaam in.</li>

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -156,12 +156,7 @@ document.getElementById("view-results").addEventListener("click", () => {
 socket.on("dictee-version", v => document.getElementById("version").textContent = `v${v}`);
 socket.on("dictee-state", (state, waiting, max) => {
     const full = (waiting === max);
-
-    if (state === "open" && !full) {
-        document.getElementById("waitAvailable").style.display = "none";
-    }else {
-        document.getElementById("waitAvailable").style.display = "";
-    }
+    document.getElementById("wait-available").style.display = state === "open" && !full ? "none" : "";
 
     const buttonText = (state === "closed") ? "Niet beschikbaar" :
       (state === "open" && full) ? "Vol" :

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -157,6 +157,12 @@ socket.on("dictee-version", v => document.getElementById("version").textContent 
 socket.on("dictee-state", (state, waiting, max) => {
     const full = (waiting === max);
 
+    if (state === "open" && !full) {
+        document.getElementById("waitAvailable").style.display = "none";
+    }else {
+        document.getElementById("waitAvailable").style.display = "";
+    }
+
     const buttonText = (state === "closed") ? "Niet beschikbaar" :
       (state === "open" && full) ? "Vol" :
       (state === "open") ? "Beschikbaar" : "Bezig";

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -156,7 +156,7 @@ document.getElementById("view-results").addEventListener("click", () => {
 socket.on("dictee-version", v => document.getElementById("version").textContent = `v${v}`);
 socket.on("dictee-state", (state, waiting, max) => {
     const full = (waiting === max);
-    document.getElementById("wait-available").style.display = state === "open" && !full ? "none" : "";
+    document.getElementById("wait-available").style.display = (state === "open" && !full) ? "none" : "";
 
     const buttonText = (state === "closed") ? "Niet beschikbaar" :
       (state === "open" && full) ? "Vol" :


### PR DESCRIPTION
### Previously
When *`la dictation`* was available it would still say:
```
Wacht tot er een dictee beschikbaar is.
```
### Now
The text
```
Wacht tot er een dictee beschikbaar is.
```
will now be removed once *`la dictation`* becomes available